### PR TITLE
Add setting to enable/disable showing lyrics screen

### DIFF
--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -84,6 +84,7 @@ static void set_defaults(player_settings_t * out) {
     out->crossfade_enabled = false;
     out->replaygain_mode = 1; /* Per Track -- preserves the old replaygain_enabled=true default */
     out->car_mode_enabled = false;
+    out->lyrics_enabled = true;
     out->subsonic_url[0] = '\0';
     out->subsonic_username[0] = '\0';
     out->subsonic_password[0] = '\0';
@@ -296,6 +297,8 @@ bool settings_load(player_settings_t * out) {
             out->replaygain_mode = atoi(value);
         } else if (strcmp(key, "car_mode_enabled") == 0) {
             out->car_mode_enabled = (strcmp(value, "1") == 0);
+        } else if (strcmp(key, "lyrics_enabled") == 0) {
+            out->lyrics_enabled = (strcmp(value, "1") == 0);
         } else if (strcmp(key, "subsonic_url") == 0) {
             snprintf(out->subsonic_url, sizeof(out->subsonic_url), "%s", value);
         } else if (strcmp(key, "subsonic_username") == 0) {
@@ -466,6 +469,7 @@ static void settings_write_file(const player_settings_t * settings) {
     fprintf(f, "crossfade=%d\n", settings->crossfade_enabled ? 1 : 0);
     fprintf(f, "replaygain_mode=%d\n", settings->replaygain_mode);
     fprintf(f, "car_mode_enabled=%d\n", settings->car_mode_enabled ? 1 : 0);
+    fprintf(f, "lyrics_enabled=%d\n", settings->lyrics_enabled ? 1 : 0);
     fprintf(f, "subsonic_url=%s\n", settings->subsonic_url);
     fprintf(f, "subsonic_username=%s\n", settings->subsonic_username);
     fprintf(f, "subsonic_password=%s\n", settings->subsonic_password);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -65,6 +65,9 @@ typedef struct {
      * resumes automatically. Off by default. */
     bool car_mode_enabled;
 
+    /* Lyrics: show lyrics screen when tapping on cover image. On by default. */
+    bool lyrics_enabled;
+
     /* Subsonic-compatible (Subsonic/Navidrome/Airsonic/...) server config.
      * Stored in plaintext like every other setting here -- this project has
      * no secure-storage mechanism (keychain, encrypted-at-rest file, etc.)

--- a/src/ui/gui.h
+++ b/src/ui/gui.h
@@ -441,6 +441,7 @@ void reserve_title_width_before(lv_obj_t * title, lv_obj_t * right_icon);
 /* ---- Busy Indicator & Notifications ---- */
 /* Notifications and Accent declared in gui_notifications.h and gui_theme.h */
 void crossfade_switch_event_cb(lv_event_t * e);
+void lyrics_switch_event_cb(lv_event_t * e);
 void car_mode_switch_event_cb(lv_event_t * e);
 void swipe_up_home_switch_event_cb(lv_event_t * e);
 void screen_dimming_switch_event_cb(lv_event_t * e);

--- a/src/ui/gui_player.c
+++ b/src/ui/gui_player.c
@@ -1542,7 +1542,9 @@ static void build_more_menu_popup(void) {
 
 static void cover_img_tap_cb(lv_event_t * e) {
     if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
-    gui_lyrics_open_screen();
+    if (current_settings.lyrics_enabled) {
+        gui_lyrics_open_screen();
+    }
 }
 
 
@@ -3327,6 +3329,12 @@ void crossfade_switch_event_cb(lv_event_t * e) {
 void car_mode_switch_event_cb(lv_event_t * e) {
     if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
     current_settings.car_mode_enabled = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
+    settings_save(&current_settings);
+}
+
+void lyrics_switch_event_cb(lv_event_t * e) {
+    if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+    current_settings.lyrics_enabled = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
     settings_save(&current_settings);
 }
 

--- a/src/ui/gui_settings.c
+++ b/src/ui/gui_settings.c
@@ -1517,8 +1517,10 @@ static lv_obj_t * build_music_controls_screen(void) {
     items[0] = (pill_list_item_t){ "Play/Pause Button", PILL_ACCESSORY_CHEVRON, false, play_pause_button_mode_settings_row_cb, NULL, NULL };
     items[1] = (pill_list_item_t){ "Car Mode", PILL_ACCESSORY_TOGGLE,
                                     current_settings.car_mode_enabled, NULL, car_mode_switch_event_cb, NULL };
+    items[2] = (pill_list_item_t){ "Lyrics", PILL_ACCESSORY_TOGGLE,
+                                    current_settings.lyrics_enabled, NULL, lyrics_switch_event_cb, NULL };
 
-    int count = 2;
+    int count = 3;
     int plugin_count = plugin_manager_get_music_controls_list_item_count();
     for (int i = 0; i < plugin_count && i < PLUGIN_MAX_MUSIC_CONTROLS_LIST_ITEMS; i++) {
         pill_list_item_t item = {


### PR DESCRIPTION
Add setting to enable/disable showing lyrics screen when tapping cover image. On by default.

Motivation: 

It is very easy to miss-tap the 'Back' button on the playback screen. This often shows the Lyrics screen instead. 

For people who do not have/want lyrics, the 'No synchronized lyrics found' text and having to swipe back is an annoyance.